### PR TITLE
Fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,18 +2,18 @@ import logo from './logo.svg'
 import './App.css'
 import {EstadoGlobal} from './components/EstadoGlobal';
 import {TesteContextApiProvider} from './store/ContexApi';
-import ProviderContexZustend from './store/ContextZuztandStore';
+import ProviderContexZustand from './store/ContextZustandStore';
 
 function App() {
   return (
     <TesteContextApiProvider>
-      <ProviderContexZustend initialNumber={2}>
+      <ProviderContexZustand initialNumber={2}>
         <div className="App">
           <header className="App-header">
              <EstadoGlobal />
           </header>
         </div>
-      </ProviderContexZustend>
+      </ProviderContexZustand>
     </TesteContextApiProvider>
 
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import logo from './logo.svg'
 import './App.css'
-import {EstadoGlonbal} from './components/EstadoGlobal';
+import {EstadoGlobal} from './components/EstadoGlobal';
 import {TesteContextApiProvider} from './store/ContexApi';
 import ProviderContexZustend from './store/ContextZuztandStore';
 
@@ -10,7 +10,7 @@ function App() {
       <ProviderContexZustend initialNumber={2}>
         <div className="App">
           <header className="App-header">
-             <EstadoGlonbal />
+             <EstadoGlobal />
           </header>
         </div>
       </ProviderContexZustend>

--- a/src/components/EstadoGlobal/index.tsx
+++ b/src/components/EstadoGlobal/index.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
 import {FiIho1} from '../FiIho1';
-import {useTesteContextApi} from '../../store/ContexApi';
-import {useZustandStore} from '../../store/ZustandStore';
-import {useStoreContextZustand} from '../../store/ContextZuztandStore';
 import logo from '../../logo.svg';
 import {useEstadoGlobalController} from './useEstadoGlobalController';
 

--- a/src/components/EstadoGlobal/index.tsx
+++ b/src/components/EstadoGlobal/index.tsx
@@ -4,7 +4,7 @@ import logo from '../../logo.svg';
 import {useEstadoGlobalController} from './useEstadoGlobalController';
 
 
-export const EstadoGlonbal: React.FC = () => {
+export const EstadoGlobal: React.FC = () => {
 
   const {
     contagem,

--- a/src/components/EstadoGlobal/index.tsx
+++ b/src/components/EstadoGlobal/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FiIho1} from '../FiIho1';
+import {Filho1} from '../Filho1';
 import logo from '../../logo.svg';
 import {useEstadoGlobalController} from './useEstadoGlobalController';
 
@@ -28,7 +28,7 @@ export const EstadoGlobal: React.FC = () => {
         <button onClick={addCountZustand}>Zustand</button>
         <button onClick={addCountZustandContext}>Zustand Context</button>
       </div>
-      <FiIho1 contagem={contagem} list={list}/>
+      <Filho1 contagem={contagem} list={list}/>
     </>
   )
 }

--- a/src/components/EstadoGlobal/useEstadoGlobalController.ts
+++ b/src/components/EstadoGlobal/useEstadoGlobalController.ts
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 import {useTesteContextApi} from '../../store/ContexApi';
 import {useZustandStore} from '../../store/ZustandStore';
-import {useStoreContextZustand} from '../../store/ContextZuztandStore';
+import {useStoreContextZustand} from '../../store/ContextZustandStore';
 
 interface EstadoGlobalControllerProps {
   contagem: number;

--- a/src/components/EstadoGlobal/useEstadoGlobalController.ts
+++ b/src/components/EstadoGlobal/useEstadoGlobalController.ts
@@ -2,10 +2,10 @@ import {useState} from 'react';
 import {useTesteContextApi} from '../../store/ContexApi';
 import {useZustandStore} from '../../store/ZustandStore';
 import {useStoreContextZustand} from '../../store/ContextZustandStore';
+import type {EstadoExemplo} from '../../store/EstadoExemplo';
+import useEstadoExemplo from "../../hooks/useEstadoExemplo";
 
-interface EstadoGlobalControllerProps {
-  contagem: number;
-  list: number[];
+interface EstadoGlobalControllerProps extends EstadoExemplo {
   addCountLocal():void;
   addCountContext():void;
   addCountZustand():void;
@@ -13,16 +13,7 @@ interface EstadoGlobalControllerProps {
 }
 
 export const useEstadoGlobalController:()=>EstadoGlobalControllerProps = ()=>{
-
-  const [contagem,setContagem] = useState<number>(0);
-  const [list,setList] = useState<number[]>([0]);
-
-  const addCountLocal = ()=>{
-    const item = contagem + 1;
-    setList([...list, item])
-    setContagem(item)
-
-  }
+  const [{contagem, list}, addCountLocal] = useEstadoExemplo();
 
   const { addCount: addCountContext } = useTesteContextApi();
   const addCountZustand = useZustandStore(store => store.addCount);

--- a/src/components/EstadoGlobal/useEstadoGlobalController.ts
+++ b/src/components/EstadoGlobal/useEstadoGlobalController.ts
@@ -1,9 +1,9 @@
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import {useTesteContextApi} from '../../store/ContexApi';
 import {useZustandStore} from '../../store/ZustandStore';
 import {useStoreContextZustand} from '../../store/ContextZuztandStore';
 
-interface EstadoGlobalControllertProps {
+interface EstadoGlobalControllerProps {
   contagem: number;
   list: number[];
   addCountLocal():void;
@@ -12,7 +12,7 @@ interface EstadoGlobalControllertProps {
   addCountZustandContext():void;
 }
 
-export const useEstadoGlobalController:()=>EstadoGlobalControllertProps = ()=>{
+export const useEstadoGlobalController:()=>EstadoGlobalControllerProps = ()=>{
 
   const [contagem,setContagem] = useState<number>(0);
   const [list,setList] = useState<number[]>([0]);

--- a/src/components/FiIho4/index.tsx
+++ b/src/components/FiIho4/index.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import {useTesteContextApi} from "../../store/ContexApi";
 import {useZustandStore} from "../../store/ZustandStore";
-import {useStoreContextZustand} from "../../store/ContextZuztandStore";
+import {useStoreContextZustand} from "../../store/ContextZustandStore";
 import {ColorRandom} from '../ColorRandom';
 interface FiIho4Props {
     contagem: number;

--- a/src/components/Filho1/index.tsx
+++ b/src/components/Filho1/index.tsx
@@ -7,11 +7,11 @@ interface Filho1Props {
   list: number[];
   children?: React.ReactNode;
 }
-export const Filho1: React.FC<Filho1Props> = ({contagem,list}) => {
+export const Filho1: React.FC<Filho1Props> = React.memo(({contagem,list}) => {
   return (
     <div className={'BoxContainer'}>
       <strong>Filho 1 <ColorRandom>{Date.now()}</ColorRandom></strong>
       <Filho2 contagem={contagem} list={list}/>
     </div>
   )
-}
+});

--- a/src/components/Filho1/index.tsx
+++ b/src/components/Filho1/index.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
-import {FiIho2} from '../FiIho2';
+import {Filho2} from '../Filho2';
 import {ColorRandom} from '../ColorRandom';
 
-interface FiIho1Props {
+interface Filho1Props {
   contagem: number;
   list: number[];
   children?: React.ReactNode;
 }
-export const FiIho1: React.FC<FiIho1Props> = ({contagem,list}) => {
+export const Filho1: React.FC<Filho1Props> = ({contagem,list}) => {
   return (
     <div className={'BoxContainer'}>
       <strong>Filho 1 <ColorRandom>{Date.now()}</ColorRandom></strong>
-      <FiIho2 contagem={contagem} list={list}/>
+      <Filho2 contagem={contagem} list={list}/>
     </div>
   )
 }

--- a/src/components/Filho2/index.tsx
+++ b/src/components/Filho2/index.tsx
@@ -1,17 +1,17 @@
 import React from "react";
-import {FiIho3} from "../FiIho3";
+import {Filho3} from "../Filho3";
 import {ColorRandom} from '../ColorRandom';
 
-interface FiIho2Props {
+interface Filho2Props {
     contagem: number;
     list: number[];
     children?: React.ReactNode;
 }
-export const FiIho2: React.FC<FiIho2Props> = ({contagem, list})=>{
+export const Filho2: React.FC<Filho2Props> = ({contagem, list})=>{
     return (
         <div className={'BoxContainer'}>
             <strong>Filho 2 <ColorRandom>{Date.now()}</ColorRandom></strong>
-            <FiIho3 contagem={contagem} list={list}/>
+            <Filho3 contagem={contagem} list={list}/>
         </div>
     )
 }

--- a/src/components/Filho3/index.tsx
+++ b/src/components/Filho3/index.tsx
@@ -1,17 +1,17 @@
 import React from "react";
-import {FiIho4} from "../FiIho4";
+import {Filho4} from "../Filho4";
 import {ColorRandom} from '../ColorRandom';
 
-interface FiIho3Props {
+interface Filho3Props {
     contagem: number;
     list: number[];
     children?: React.ReactNode;
 }
-export const FiIho3: React.FC<FiIho3Props> = ({contagem,list})=>{
+export const Filho3: React.FC<Filho3Props> = ({contagem,list})=>{
     return (
         <div  className={'BoxContainer'}>
             <strong>Filho 3 <ColorRandom>{Date.now()}</ColorRandom></strong>
-            <FiIho4 contagem={contagem} list={list}/>
+            <Filho4 contagem={contagem} list={list}/>
         </div>
     )
 }

--- a/src/components/Filho4/index.tsx
+++ b/src/components/Filho4/index.tsx
@@ -5,12 +5,12 @@ import {useTesteContextApi} from "../../store/ContexApi";
 import {useZustandStore} from "../../store/ZustandStore";
 import {useStoreContextZustand} from "../../store/ContextZustandStore";
 import {ColorRandom} from '../ColorRandom';
-interface FiIho4Props {
+interface Filho4Props {
     contagem: number;
     list: number[];
     children?: React.ReactNode;
 }
-export const FiIho4: React.FC<FiIho4Props> = ({contagem:contagemLocal, list:listLocal})=>{
+export const Filho4: React.FC<Filho4Props> = ({contagem:contagemLocal, list:listLocal})=>{
 
     const {contagem, list} = useTesteContextApi()
     const  contagemZ = useZustandStore(store => store.contagem)

--- a/src/hooks/useEstadoExemplo.ts
+++ b/src/hooks/useEstadoExemplo.ts
@@ -1,0 +1,22 @@
+import {useCallback, useState} from "react";
+
+import {addCount, emptyEstadoExemplo, type EstadoExemplo} from "../store/EstadoExemplo";
+
+const useEstadoExemplo = (): [EstadoExemplo, () => void]=> {
+    const [estado, setEstado] = useState<EstadoExemplo>(emptyEstadoExemplo);
+
+    // useCallback é utilizado para manter addCountLocal estável durante a vida do componente,
+    // ele não tem dependências que mudam (setEstado é sempre o mesmo), logo ela nunca muda,
+    // essencial para React.memo(), useMemo(), useCallback() ou qualquer outra dependência.
+    const addCountLocal = useCallback(() => {
+      // sempre utilize o prevState se o próximo estado depende do anterior:
+      // https://reactjs.org/docs/faq-state.html#why-is-setstate-giving-me-the-wrong-value
+      // https://reactjs.org/docs/faq-state.html#how-do-i-update-state-with-values-that-depend-on-the-current-state
+      // logo fica igual ao miolo em ProviderContexZustand
+      setEstado(addCount);
+    }, [setEstado]);
+
+    return [estado, addCountLocal];
+};
+
+export default useEstadoExemplo;

--- a/src/store/ContexApi.tsx
+++ b/src/store/ContexApi.tsx
@@ -1,4 +1,6 @@
-import React, {createContext, useContext, useState} from "react";
+import React, {createContext, useContext, useMemo} from "react";
+
+import useEstadoExemplo from "../hooks/useEstadoExemplo";
 
 interface TesteContextProps {
     contagem: number;
@@ -13,15 +15,17 @@ interface TesteContextApiProps{
 }
 
 export const TesteContextApiProvider: React.FC<TesteContextApiProps> =({children})=>{
-    const [contagem,setContagem] = useState<number>(0);
-    const [list,setList] = useState<number[]>([0]);
-    const addCount = ()=>{
-        const item = contagem + 1;
-        setList([...list, item])
-        setContagem(item)
-    }
+    const [{contagem, list}, addCount] = useEstadoExemplo();
+
+    // Atenção: Provider vai atualizar todos os usuários sempre que o `value` mudar,
+    // logo precisamos mantê-lo estável a não ser que algo interno mude (ex: contagem, list ou addCount)
+    const value = useMemo((): TesteContextProps => ({
+        addCount,
+        contagem,
+        list,
+    }), [addCount, contagem, list]);
     return (
-        <TesteContext.Provider value={{contagem, addCount, list}}>
+        <TesteContext.Provider value={value}>
             {children}
         </TesteContext.Provider>
     )

--- a/src/store/ContextZustandStore.tsx
+++ b/src/store/ContextZustandStore.tsx
@@ -1,13 +1,11 @@
-import create, {State, StoreApi} from 'zustand';
+import create, {StoreApi} from 'zustand';
 import createContext from 'zustand/context';
 
 import React from 'react';
 
-interface TesteContextProps {
-  contagem: number;
-  list: number[];
-  addCount(): void;
-}
+import {addCount, type EstadoExemplo} from "./EstadoExemplo";
+
+type TesteContextProps = EstadoExemplo & Readonly<{ addCount(): void }>;
 
 interface TesteContextProviderProps {
   initialNumber: number;
@@ -19,13 +17,7 @@ const {Provider, useStore} = createContext<TesteContextProps & StoreApi<TesteCon
 const createStore = (initialNumber: number) => ()=> create<TesteContextProps>(set => ({
   contagem: initialNumber,
   list: [initialNumber],
-  addCount: () => set(state => {
-    const value = state.contagem + 1
-    return {
-      list: [...state.list, value],
-      contagem: value
-    }
-  })
+  addCount: () => set(addCount),
 }))
 export const ProviderContexZustand: React.FC<TesteContextProviderProps> = ({initialNumber, children}) => {
   return (

--- a/src/store/ContextZustandStore.tsx
+++ b/src/store/ContextZustandStore.tsx
@@ -27,7 +27,7 @@ const createStore = (initialNumber: number) => ()=> create<TesteContextProps>(se
     }
   })
 }))
-export const ProviderContexZustend: React.FC<TesteContextProviderProps> = ({initialNumber, children}) => {
+export const ProviderContexZustand: React.FC<TesteContextProviderProps> = ({initialNumber, children}) => {
   return (
     <Provider createStore={createStore(initialNumber) as any}> {children} </Provider>
   );
@@ -35,5 +35,5 @@ export const ProviderContexZustend: React.FC<TesteContextProviderProps> = ({init
 
 export const useStoreContextZustand = useStore;
 
-export default ProviderContexZustend;
+export default ProviderContexZustand;
 

--- a/src/store/ContextZustandStore.tsx
+++ b/src/store/ContextZustandStore.tsx
@@ -13,7 +13,7 @@ interface TesteContextProviderProps {
 }
 
 
-const {Provider, useStore} = createContext<TesteContextProps & StoreApi<TesteContextProps>>();
+const {Provider, useStore} = createContext<StoreApi<TesteContextProps>>();
 const createStore = (initialNumber: number) => ()=> create<TesteContextProps>(set => ({
   contagem: initialNumber,
   list: [initialNumber],
@@ -21,7 +21,7 @@ const createStore = (initialNumber: number) => ()=> create<TesteContextProps>(se
 }))
 export const ProviderContexZustand: React.FC<TesteContextProviderProps> = ({initialNumber, children}) => {
   return (
-    <Provider createStore={createStore(initialNumber) as any}> {children} </Provider>
+    <Provider createStore={createStore(initialNumber)}> {children} </Provider>
   );
 };
 

--- a/src/store/EstadoExemplo.ts
+++ b/src/store/EstadoExemplo.ts
@@ -1,0 +1,14 @@
+export type EstadoExemplo = Readonly<{
+    contagem: number;
+    list: number[];
+}>;
+
+export const emptyEstadoExemplo: EstadoExemplo = { contagem: 0, list: [0] };
+
+export const addCount = (prevState: EstadoExemplo): EstadoExemplo => {
+    const value = prevState.contagem + 1
+    return {
+        contagem: value,
+        list: [...prevState.list, value],
+    };
+};

--- a/src/store/ZustandStore.ts
+++ b/src/store/ZustandStore.ts
@@ -1,20 +1,10 @@
 import create from 'zustand'
 
-interface TesteContextProps {
-    contagem: number;
-    list: number[];
-    addCount():void;
-}
+import {addCount, emptyEstadoExemplo, type EstadoExemplo} from "./EstadoExemplo";
 
-export const useZustandStore = create<TesteContextProps>((set, get) => ({
-    contagem: 0,
-    list: [0],
-    addCount: () => set(state => {
-        const value = state.contagem + 1
-        return {
-            list: [...state.list, value],
-            contagem: value
-        }
-    }),
+type TesteContextProps = EstadoExemplo & Readonly<{ addCount():void }>;
 
+export const useZustandStore = create<TesteContextProps>((set) => ({
+    ...emptyEstadoExemplo,
+    addCount: () => set(addCount),
 }))


### PR DESCRIPTION
Corrige uns typos e ajusta a performance para mostrar que ContextApi ou Zustand com Context são tão eficientes quanto o Zustand store. Claro, temos um grau de dificuldade maior e chances de erro (como aconteceu no exemplo "naive").

Atenção especial para os pontos:

- Erros no uso de `setState` confiando no valor anterior, referências:
  - https://reactjs.org/docs/faq-state.html#why-is-setstate-giving-me-the-wrong-value
  - https://reactjs.org/docs/faq-state.html#how-do-i-update-state-with-values-that-depend-on-the-current-state
- `<Provider value={value}>` atualiza TODO mundo que usa (`useContext`/`Consumer`) quando `value` muda, logo é necessário passar um `value` estável (memoized).
- É recomendado que todo filho direto de `Provider` tenha um `React.memo()` para evitar que ele e a árvore imediata atualizem quando ele atualizar, este é o ponto fundamental para resolver problema na maioria das aplicações que usam context direta ou indiretamente, joga o `React.memo()` no componente que oferece o primeiro componente visual (navigation, etc).